### PR TITLE
revert FB specific changes and change to package to accept msg arg

### DIFF
--- a/client/templates/services.jsx
+++ b/client/templates/services.jsx
@@ -161,31 +161,50 @@ ServicesList = React.createClass({
  */
 var AppServiceList = React.createClass({
   _DEV_renderServiceList(key) {
-    var service = this.props.services[key]
-    return (
-     <div key={service.name}>
-       <button className={"btn-large social-button " + service.name } onClick={this.props.add.bind(null, service.name)}>Add {service.name}</button>
-       <button className={"btn-large social-button " + service.name } onClick={this.props.remove.bind(null, service.name)}>Remove {service.name}</button>
-       <br /><br />
-     </div>
-    )
-  
-    // var serviceState = this.props.activeAppList[service];
-    //
-    // if (serviceState && serviceState.state === true) {
-    //   return (
-    //     <div key={service}>
-    //       <button className={"btn-large social-button " + service } onClick={this.props.remove.bind(null, service)}>Remove {service}</button>
-    //       <br /><br />
-    //     </div>
-    //   )
-    // }
+    var service = this.props.services[key].name;
     // return (
-    //   <div key={service}>
-    //     <button className={"btn-large social-button " + service } onClick={this.props.add.bind(null, service)}>Add {service}</button>
-    //     <br /><br />
-    //   </div>
+    //  <div key={service.name}>
+    //    <button className={"btn-large social-button " + service.name } onClick={this.props.add.bind(null, service.name)}>Add {service.name}</button>
+    //    <button className={"btn-large social-button " + service.name } onClick={this.props.remove.bind(null, service.name)}>Remove {service.name}</button>
+    //    <br /><br />
+    //  </div>
     // )
+  
+    var serviceState = this.props.activeAppList[service];
+    
+    if (serviceState && serviceState.state === true) {
+      return (
+        <div key={service}>
+          <button className={"btn-large social-button " + service } onClick={this.props.remove.bind(null, service)}>Remove {service}</button>
+          <br /><br />
+        </div>
+      )
+    }
+    return (
+      <div key={service}>
+        <button className={"btn-large social-button " + service } onClick={this.props.add.bind(null, service)}>Add {service}</button>
+        <br /><br />
+      </div>
+    )
+  },
+  renderServiceList(service) {
+    //console.log('check2: ', this.props.activeAppList[service]);
+    var serviceState = this.props.activeAppList[service].state;
+
+    if (serviceState) {
+      return (
+        <div key={service}>
+          <button className={"btn-large social-button " + service } onClick={this.props.remove.bind(null, service)}>Remove {service}</button>
+          <br /><br />
+        </div>
+      )
+    }
+    return (
+      <div key={service}>
+        <button className={"btn-large social-button " + service } onClick={this.props.add.bind(null, service)}>Add {service}</button>
+        <br /><br />
+      </div>
+    )
   },
   loginTwitter(options, callback) {
     Meteor.call('twitterGetToken', function(err, result) {
@@ -207,45 +226,22 @@ var AppServiceList = React.createClass({
     })
   },
   testTwitterPost(){
-    Meteor.call('twitterPost', function(err, results){});
-  },
-  renderServiceList(service) {
-    //console.log('check2: ', this.props.activeAppList[service]);
-    var serviceState = this.props.activeAppList[service].state;
-
-    if (serviceState) {
-      return (
-        <div key={service}>
-          <button className={"btn-large social-button " + service } onClick={this.props.remove.bind(null, service)}>Remove {service}</button>
-          <br /><br />
-        </div>
-      )
-    }
-    return (
-      <div key={service}>
-        <button className={"btn-large social-button " + service } onClick={this.props.add.bind(null, service)}>Add {service}</button>
-        <br /><br />
-      </div>
-    )
+    var tweet = 'hello world!'
+    Meteor.call('twitterPost', tweet, function(err, results){});
   },
   render: function () {
-    // console.log('services: ', this.props.services);
-    // console.log('active services: ', this.props.activeAppList);
-    //<p className="flow-text">MANAGE SERVICES</p>
-    //    {Object.keys(this.props.activeAppList).map(this.renderServiceList)}
-    //    <br /><br />
-    //    <br /><br />
-    //    <br /><br />
-    //    <br /><br />
-    //    <button className="btn" onClick={this.loginTwitter}>Test Twitter</button>
-    //    <br /><br />
-    //    <button className="btn" onClick={this.loginTumblr}>Test Tumblr</button>
-    //    <br /><br />
     return (
       <div>
         <p className="flow-text">MANAGE SERVICES</p>
         {Object.keys(this.props.services).map(this._DEV_renderServiceList)}
         <p>BACK TO <a href="/">UPLOADS</a></p>
+        // <br /><br />
+        // <button className="btn" onClick={this.props.imgurToken}>Set Imgur Token</button>
+        // <br /><br />
+        // <button className="btn" onClick={this.loginTwitter}>Test Twitter</button>
+        // <br /><br />
+        // <button className="btn" onClick={this.loginTumblr}>Test Tumblr</button>
+        // <br /><br />
       </div>
     )
   }

--- a/packages/justshiv:oauth-snapshare/oauth_ss_server.js
+++ b/packages/justshiv:oauth-snapshare/oauth_ss_server.js
@@ -83,7 +83,7 @@ OAuth_SS.prototype.generateAccessToken = function(params) {
   UserServices.upsert({userId: Meteor.userId}, {$set: query});
 };
 
-OAuth_SS.prototype.post =  function(){
+OAuth_SS.prototype.post =  function(tweet){
   //console.log('twitter');
   var self = this;
   self.accessToken = UserServices.findOne({userId: Meteor.userId()}).services.twitter.accessToken;
@@ -93,31 +93,11 @@ OAuth_SS.prototype.post =  function(){
   oauthBinding.accessToken = self.accessToken;
   oauthBinding.accessTokenSecret = self.accessTokenSecret;
 
-  var params = { status: 'test' };
+  var params = { status: tweet };
 
   var result = oauthBinding.call('POST', 'https://api.twitter.com/1.1/statuses/update.json', params);
   console.log('result: ', result);
-  //var headers = oauthBinding._buildHeader({
-  //  accessToken: self.accessToken
-  //});
-  //console.log(headers);
-  //var response =  oauthBinding._call('POST', "https://upload.twitter.com/1.1/media/upload.json?status=Maybe%20he%27ll%20finally%20find%20his%20keys.%20%23peterfalk", headers);
-  //var tokens = queryStringToJSON(response.content);
-  //console.log(tokens);
-
-  //HTTP.post("https://api.twitter.com/1.1/statuses/update.json", {
-  //  data: {image: url},
-  //  headers: {
-  //    Authorization: headers
-  //  }
-  //}, function (error, result) {
-  //  if(error) {
-  //    console.log(error);
-  //  }
-  //  else{
-  //    console.log('result: ', result);
-  //  }
-  //})
+  return result;
 };
 function queryStringToJSON(str) {
   var pairs = str.split('&');

--- a/server/services/twitter.jsx
+++ b/server/services/twitter.jsx
@@ -38,8 +38,8 @@ Meteor.methods({
   // verifyAuth: function() {
   //   return twitter.verifyService();
   // }
-  twitterPost: function(){
+  twitterPost: function(tweet){
     console.log('twitter');
-    twitter.post();
+    twitter.post(tweet);
   }
 });


### PR DESCRIPTION
- Updated how services are being toggled true in the services table as the behavior was inconsistent (conflict with the merge package operations). The invocation of toggle isn't centralized at the moment on service add. The toggle method is only set up with Facebook and remove service trigger.
- Updated the post method in the oauth_ss package to take a string arg and post it. Previously in a test state.
- Reapplied the service add/remove toggle functionality. 
